### PR TITLE
fix edit button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,13 +1,16 @@
 site_name: Nuclei - Community Powered Vulnerability Scanner
 site_description: Learn how to use Nuclei engine to write your own custom security checks with very simple and easy to use templating syntax.
 site_url: https://nuclei.projectdiscovery.io
-repo_url: https://github.com/projectdiscovery/nuclei/
-copyright: Copyright &copy; 2021 ProjectDiscovery, Inc.
+repo_url: https://github.com/projectdiscovery/nuclei-docs/
+repo_name: GitHub
+edit_uri: edit/main/docs/
+copyright: Copyright &copy; 2023 ProjectDiscovery, Inc.
 
 # Configuration
 theme:
   features:
     - tabs
+    - content.action.edit
   name: null
   custom_dir: material
 


### PR DESCRIPTION
Fix this:

![image](https://user-images.githubusercontent.com/16578570/211078592-af132653-ace7-4201-8995-ee20ac1fecd8.png)


- Explicitly enable the edit button https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#code-actions 
- fix repo_url else it open to https://github.com/projectdiscovery/nuclei/edit/master/docs/nuclei/get-started.md instead of https://github.com/projectdiscovery/nuclei-docs/edit/main/docs/nuclei/get-started.md
- also add https://www.mkdocs.org/user-guide/configuration/#edit_uri to fix edit URI else it targets master instead of main
- update copyright year